### PR TITLE
Fix sidebar navigation arrow icon

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  rotateIcon?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,12 +18,20 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  rotateIcon = false,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(
+            styles.icon,
+            isCollapsed && rotateIcon && styles.rotate,
+          )}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -29,4 +29,9 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+  transition: all 300ms ease;
+
+  &.rotate {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -91,6 +91,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
+              rotateIcon={true}
             />
           </ul>
         </nav>


### PR DESCRIPTION
The arrow of the collapse button points to the right when the sidebar navigation is collapsed.