### PR TITLE
Fix navigation support button

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -3,6 +3,8 @@ describe("Sidebar Navigation", () => {
     cy.visit("http://localhost:3000/dashboard");
   });
 
+  const mailto = "mailto:support@prolog-app.com?subject=Support Request:";
+
   context("desktop resolution", () => {
     beforeEach(() => {
       cy.viewport(1025, 900);
@@ -29,6 +31,9 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      // link to support email is correct
+      cy.get("nav").contains("Support").should("have.attr", "href", mailto);
     });
 
     it("is collapsible", () => {
@@ -36,7 +41,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,10 +85,12 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");
+      // Link to support email is correct
+      cy.get("nav").contains("Support").should("have.attr", "href", mailto);
       cy.get("nav").contains("Collapse").should("not.be.visible");
 
       // close mobile navigation and check that it disappears

--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  rotateIcon?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,12 +18,20 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  rotateIcon = false,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(
+            styles.icon,
+            isCollapsed && rotateIcon && styles.rotate,
+          )}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -29,4 +29,9 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+  transition: all 300ms ease;
+
+  &.rotate {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,11 +79,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href="mailto:support@prolog-app.com?subject=Support Request:"
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -91,6 +91,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
+              rotateIcon={true}
             />
           </ul>
         </nav>


### PR DESCRIPTION
- Change the support button from MenuItemButton to a MenuItemLink component to take advantage of the href prop.
- Add tests to check if the support link has the correct mail and subject info, in both desktop and mobile resolutions.
- Modify existing navigation tests to take into account the support link added.